### PR TITLE
Add Mermaid sequence diagram feature to PR descriptions

### DIFF
--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -6,8 +6,8 @@
 
 [config]
 # models
-model="o4-mini"
-fallback_models=["gpt-4.1"]
+model="gemini/gemini-1.5-flash
+fallback_models=["gemini/gemini-1.5-flash"]
 #model_reasoning="o4-mini" # dedictated reasoning model for self-reflection
 #model_weak="gpt-4o" # optional, a weaker model to use for some easier tasks
 # CLI
@@ -26,7 +26,7 @@ disable_auto_feedback = false
 ai_timeout=120 # 2minutes
 skip_keys = []
 custom_reasoning_model = false # when true, disables system messages and temperature controls for models that don't support chat-style inputs
-response_language="en-US" # Language locales code for PR responses in ISO 3166 and ISO 639 format (e.g., "en-US", "it-IT", "zh-CN", ...)
+response_language="ko-KR" # Language locales code for PR responses in ISO 3166 and ISO 639 format (e.g., "en-US", "it-IT", "zh-CN", ...)
 # token limits
 max_description_tokens = 500
 max_commits_tokens = 500
@@ -101,6 +101,7 @@ enable_pr_type=true
 final_update_message = true
 enable_help_text=false
 enable_help_comment=true
+add_diagram=true
 # describe as comment
 publish_description_as_comment=false
 publish_description_as_comment_persistent=true

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -6,7 +6,7 @@
 
 [config]
 # models
-model="gemini/gemini-1.5-flash
+model="gemini/gemini-1.5-flash"
 fallback_models=["gemini/gemini-1.5-flash"]
 #model_reasoning="o4-mini" # dedictated reasoning model for self-reflection
 #model_weak="gpt-4o" # optional, a weaker model to use for some easier tasks

--- a/pr_agent/settings/pr_description_prompts.toml
+++ b/pr_agent/settings/pr_description_prompts.toml
@@ -6,6 +6,7 @@ Your task is to provide a full description for the PR content - type, descriptio
 - The generated title and description should prioritize the most significant changes.
 - If needed, each YAML output should be in block scalar indicator ('|')
 - When quoting variables, names or file paths from the code, use backticks (`) instead of single quote (').
+- Generate a Mermaid sequence diagram that shows the key function or component calls that were added or changed in this PR.
 
 {%- if extra_instructions %}
 
@@ -45,6 +46,7 @@ class FileDescription(BaseModel):
 class PRDescription(BaseModel):
     type: List[PRType] = Field(description="one or more types that describe the PR content. Return the label member value (e.g. 'Bug fix', not 'bug_fix')")
     description: str = Field(description="summarize the PR changes in up to four bullet points, each up to 8 words. For large PRs, add sub-bullets if needed. Order bullets by importance, with each bullet highlighting a key change group.")
+    sequence_diagram: str = Field(description="a Mermaid sequence diagram that visualizes key function or component calls that were added or changed in this PR. Use proper Mermaid syntax with 'sequenceDiagram' at the beginning.")
     title: str = Field(description="a concise and descriptive title that captures the PR's main theme")
 {%- if enable_semantic_files_types %}
     pr_files: List[FileDescription] = Field(max_items=20, description="a list of all the files that were changed in the PR, and summary of their changes. Each file must be analyzed regardless of change size.")
@@ -60,6 +62,12 @@ type:
 - ...
 description: |
   ...
+sequence_diagram: |
+  sequenceDiagram
+    participant A as ComponentA
+    participant B as ComponentB
+    A->>B: functionCall()
+    B-->>A: response
 title: |
   ...
 {%- if enable_semantic_files_types %}
@@ -141,6 +149,12 @@ type:
 - ...
 description: |
   ...
+sequence_diagram: |
+  sequenceDiagram
+    participant A as ComponentA
+    participant B as ComponentB
+    A->>B: functionCall()
+    B-->>A: response
 title: |
   ...
 {%- if enable_semantic_files_types %}

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -73,7 +73,7 @@ class PRDescription:
             "related_tickets": "",
             "include_file_summary_changes": len(self.git_provider.get_diff_files()) <= self.COLLAPSIBLE_FILE_LIST_THRESHOLD,
             'duplicate_prompt_examples': get_settings().config.get('duplicate_prompt_examples', False),
-            "add_diagram": get_settings().pr_description.get('add_diagram', True),
+            "add_diagram": True if getattr(get_settings().pr_description, "add_diagram", True) else False,
         }
 
         self.user_description = self.git_provider.get_user_description()

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -73,6 +73,7 @@ class PRDescription:
             "related_tickets": "",
             "include_file_summary_changes": len(self.git_provider.get_diff_files()) <= self.COLLAPSIBLE_FILE_LIST_THRESHOLD,
             'duplicate_prompt_examples': get_settings().config.get('duplicate_prompt_examples', False),
+            "add_diagram": get_settings().pr_description.add_diagram,
         }
 
         self.user_description = self.git_provider.get_user_description()
@@ -518,6 +519,12 @@ class PRDescription:
             summary = f"{ai_header}{ai_summary}"
             body = body.replace('pr_agent:summary', summary)
 
+        # Handle sequence diagram if present
+        ai_sequence_diagram = self.data.get('sequence_diagram')
+        if ai_sequence_diagram and not re.search(r'<!--\s*pr_agent:sequence_diagram\s*-->', body):
+            diagram = f"{ai_header}```mermaid\n{ai_sequence_diagram}\n```"
+            body = body.replace('pr_agent:sequence_diagram', diagram)
+        
         ai_walkthrough = self.data.get('pr_files')
         walkthrough_gfm = ""
         pr_file_changes = []
@@ -592,6 +599,9 @@ class PRDescription:
                     value = ', '.join(v.rstrip() for v in value)
                 value = value.replace('\n-', '\n\n-').strip() # makes the bullet points more readable by adding double space
                 pr_body += f"{value}\n"
+            elif key.lower().strip() == 'sequence_diagram':
+                # Add the Mermaid sequence diagram to the PR body
+                pr_body += f"```mermaid\n{value}\n```\n"
             else:
                 # if the value is a list, join its items by comma
                 if isinstance(value, list):

--- a/pr_agent/tools/pr_description.py
+++ b/pr_agent/tools/pr_description.py
@@ -73,7 +73,7 @@ class PRDescription:
             "related_tickets": "",
             "include_file_summary_changes": len(self.git_provider.get_diff_files()) <= self.COLLAPSIBLE_FILE_LIST_THRESHOLD,
             'duplicate_prompt_examples': get_settings().config.get('duplicate_prompt_examples', False),
-            "add_diagram": get_settings().pr_description.add_diagram,
+            "add_diagram": get_settings().pr_description.get('add_diagram', True),
         }
 
         self.user_description = self.git_provider.get_user_description()

--- a/tests/unittest/test_file_filter.py
+++ b/tests/unittest/test_file_filter.py
@@ -43,7 +43,7 @@ class TestIgnoreFilter:
         """
         Test files are ignored when regex patterns are specified.
         """
-        monkeypatch.setattr(global_settings.ignore, 'regex', ['^file[2-4]\..*$'])
+        monkeypatch.setattr(global_settings.ignore, 'regex', [r'^file[2-4]\..*$'])
 
         files = [
             type('', (object,), {'filename': 'file1.py'})(),
@@ -64,7 +64,7 @@ class TestIgnoreFilter:
         """
         Test invalid patterns are quietly ignored.
         """
-        monkeypatch.setattr(global_settings.ignore, 'regex', ['(((||', '^file[2-4]\..*$'])
+        monkeypatch.setattr(global_settings.ignore, 'regex', [r'(((||', r'^file[2-4]\..*$'])
 
         files = [
             type('', (object,), {'filename': 'file1.py'})(),


### PR DESCRIPTION
### **User description**
## 변경 사항
- PR 설명에 Mermaid 시퀀스 다이어그램 기능 추가
- PR 설명 프롬프트에 다이어그램 생성 지시 및 필드 추가
- 마커 기반 및 일반 PR 설명 출력 포맷에 다이어그램 지원 추가

## 이점
- PR의 주요 함수 및 컴포넌트 호출을 시각적으로 표현 가능
- 코드 변경 사항의 흐름과 상호작용을 더 쉽게 이해 가능
- 복잡한 변경 사항에 대한 시각적 문서화 제공


___

### **PR Type**
Enhancement, Configuration changes, Documentation, Bug fix


___

### **Description**
- Add Mermaid sequence diagram support to PR descriptions
  - Update prompt and output schema to include sequence diagrams
  - Render Mermaid diagrams in both marker-based and standard PR outputs

- Update configuration to enable diagram generation by default
  - Add `add_diagram` setting to configuration
  - Switch default model to Gemini and set Korean as response language

- Fix test regex patterns to use raw strings

- Improve safe access to configuration settings in code


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_description.py</strong><dd><code>Integrate Mermaid sequence diagrams into PR description generation</code></dd></summary>
<hr>

pr_agent/tools/pr_description.py

<li>Add logic to include Mermaid sequence diagrams in PR descriptions<br> <li> Render diagrams in both marker-based and standard PR body outputs<br> <li> Use getattr for safe access to <code>add_diagram</code> setting


</details>


  </td>
  <td><a href="https://github.com/OSSCA-2025-Egg-Benedict/pr-agent/pull/20/files#diff-66130451adce278a098a5770e2db52b12050205fcd4d80c13f813615d4449abb">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_description_prompts.toml</strong><dd><code>Add Mermaid sequence diagram instructions and schema to prompts</code></dd></summary>
<hr>

pr_agent/settings/pr_description_prompts.toml

<li>Update prompt to instruct Mermaid sequence diagram generation<br> <li> Add <code>sequence_diagram</code> field to output schema and YAML examples<br> <li> Provide Mermaid syntax and usage instructions in prompt


</details>


  </td>
  <td><a href="https://github.com/OSSCA-2025-Egg-Benedict/pr-agent/pull/20/files#diff-a52546bc2f8a156d8ee786c403e44b1561a6e3f1d98fcfbe8a0120bcee59981b">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.toml</strong><dd><code>Update configuration for diagram support and model defaults</code></dd></summary>
<hr>

pr_agent/settings/configuration.toml

<li>Add <code>add_diagram</code> setting to enable diagram generation<br> <li> Change default model to Gemini 1.5 Flash<br> <li> Set response language to Korean


</details>


  </td>
  <td><a href="https://github.com/OSSCA-2025-Egg-Benedict/pr-agent/pull/20/files#diff-66cfda5143e484ee53ecf7aa0df7dca8ad0b181256f4b0675905db35bcbbae78">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_file_filter.py</strong><dd><code>Fix regex patterns in file filter tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unittest/test_file_filter.py

- Fix test regex patterns to use raw strings for correctness


</details>


  </td>
  <td><a href="https://github.com/OSSCA-2025-Egg-Benedict/pr-agent/pull/20/files#diff-3027c17fd045d59c760cb3fd8b6ce72c3e333667ed2466acb99a3f5c3faa2803">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>